### PR TITLE
readme: Add Steam Play to project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Boxtron Discord](https://img.shields.io/discord/514567252864008206.svg?label=discord)](https://discord.gg/8mFhUPX)
 [![Say Thanks!](https://img.shields.io/badge/Say%20Thanks-!-1EAEDB.svg)](https://saythanks.io/to/dreamer)
 
-Steam Play compatibility tool to run DOS games on Steam through native Linux DOSBox.
+Steam Play compatibility tool to run DOS games through native Linux DOSBox.
 
 This is a sister project of [Luxtorpeda](https://github.com/dreamer/luxtorpeda).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Boxtron Discord](https://img.shields.io/discord/514567252864008206.svg?label=discord)](https://discord.gg/8mFhUPX)
 [![Say Thanks!](https://img.shields.io/badge/Say%20Thanks-!-1EAEDB.svg)](https://saythanks.io/to/dreamer)
 
-Compatibility tool to run DOS games on Steam through native Linux DOSBox.
+Steam Play compatibility tool to run DOS games on Steam through native Linux DOSBox.
 
 This is a sister project of [Luxtorpeda](https://github.com/dreamer/luxtorpeda).
 


### PR DESCRIPTION
Added Steam Play to project description to indicate clearly that the tool is used as a part of *Steam Play*, paraphrasing what the screenshot below says. Having it in textual description may ease up indexing and finding the project in search engines, too.

Will do the same PR for Luxtorpeda. Project description on GitHub could use similar update as well.