### PR TITLE
Add NixOS Prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ and a soundfont.  Optionally, you can use FluidSynth as well.
 
     $ sudo pacman -S dosbox inotify-tools timidity++ soundfont-fluid
 
+#### NixOS
+
+    $ nix-env -f '<nixpkgs>' -iA dosbox inotify-tools timidity soundfont-fluid
 
 ## Installation (using tarball)
 


### PR DESCRIPTION
Add NixOS Prerequisites to the README.md

I have tested Boxtron on NixOS 19.09 and can confirm it's working for me.