### PR TITLE
Lords of the Realm I tweaks

### DIFF
--- a/tweaks.py
+++ b/tweaks.py
@@ -282,6 +282,17 @@ TWEAKS_DB = {
             },
         },
     },
+    # Lords of the Realm
+    'steam:254920': {
+        'commands': {
+            r'.*':  {
+                'args': ['-c', 'mount C "../../Lords of the Realm I"',
+                         '-c', 'C:',
+                         '-c', 'lords.exe',
+                         '-c', 'exit'],
+            },
+        },
+    },
 }  # yapf: disable
 
 


### PR DESCRIPTION
Lords of the Realm I ships with a launcher .exe for Windows, so Boxtron doesn't work without explicitly specifying where to find the game. DosBox starts up from "$steamapps/common/Lords of the Realm I/English/DOSBOX/Launcher", so we need to mount C: relative from there.

Besides this, game seems to run fine with default settings, although the game does ship with various conf files (notably dosboxLords1.conf and dosboxLords1_single.conf), defining these in the tweaks file doesn't generate particularly different generated confs (maybe I'm declaring them wrong?):

defaults:
```
# Generated by Boxtron
# Based on args to Windows version of DOSBox:
# ['-c', 'mount C "../../Lords of the Realm I"', '-c', 'C:', '-c', 'lords.exe', '-c', 'exit']

[sdl]
# fullscreen=true
# output=opengl
# autolock=false

[autoexec]
mount C "../../Lords of the Realm I"
C:
lords.exe
exit
```
With confs:
```
# Generated by Boxtron
# Based on args to Windows version of DOSBox:
# ['-conf', '../../Lords of the Realm I/dosboxLords1.conf', '-conf', '../../Lords of the Realm I/dosboxLords1_single.conf', '-noautoexec', '-c', 'mount C "../../Lords of the Realm I"', '-c', 'C:', '-c', 'lords.exe', '-c', 'exit']

[sdl]
# fullscreen=true
# output=opengl
# autolock=false

[render]
# aspect: Do aspect correction for games using 320x200 resolution.
#         Read more: https://www.dosbox.com/wiki/Dosbox.conf#aspect
# scaler: Specifies which scaler is used to enlarge and enhance low resolution
#         modes, before any scaling done through OpenGL.
#         Read more: https://www.dosbox.com/wiki/Dosbox.conf#scaler
# aspect=false
# scaler=normal2x

[autoexec]
mount C "../../Lords of the Realm I"
C:
lords.exe
exit
```
TBH, the audio seems glitchier /with/ the confs specified, although this may just be a nocebo effect? It runs fine with defaults, so that's what I'm including in the pull request.