### PR TITLE
fix: fluidsynth closes on launch when stdin = /dev/null

### DIFF
--- a/midi.py
+++ b/midi.py
@@ -115,7 +115,7 @@ def start_timidity(sfont):
 
 def start_fluidsynth(sfont):
     """Start FluidSynth process."""
-    cmd = ['fluidsynth', '-a', 'pulseaudio', sfont]
+    cmd = ['fluidsynth', '-sia', 'pulseaudio', sfont]
     proc = subprocess.Popen(cmd, shell=False, stdout=subprocess.DEVNULL)
     log('Starting MIDI client (pid: {0})'.format(proc.pid))
     log('Using soundfont: {}'.format(sfont))


### PR DESCRIPTION
fluidsynth will quit on launch if it can't read from stdin, start it on server mode to make it ignore stdin and keep running indefinitely